### PR TITLE
Switch create-pull-request action to build from Dockerfile

### DIFF
--- a/github/create-pull-request/action.yml
+++ b/github/create-pull-request/action.yml
@@ -3,7 +3,7 @@ author: 'Peter Evans'
 description: 'Creates a pull request for changes to your repository in the actions workspace'
 runs:
   using: 'docker'
-  image: 'docker://peterevans/create-pull-request:1.6.1'
+  image: 'Dockerfile'
 branding:
   icon: 'git-pull-request'  
   color: 'gray-dark'


### PR DESCRIPTION
Hi @osterman
You mentioned on the [GitHub community forms post here](https://github.community/t5/GitHub-Actions/GitHub-Actions-Not-Run-on-PR-Generated-by-GitHub-Actions/m-p/37568/highlight/true#M3003) that you forked for security. That's good and recommended! However, the action is still building from my tagged pre-built container.

This PR switches from using my pre-built container to building from the included `Dockerfile`. The downside to this is that it will add 10-15 seconds or so to the workflow execution time.

I'm planning to switch [create-pull-request](https://github.com/peter-evans/create-pull-request) action to a container-less style of action. I already have that version in beta and can be used with the `-multi` suffix release tags. I will probably make this the main version soon. When that happens if you fork again you will get security from having your own copy and it will be faster than building the Docker image each time.