### PR TITLE
[go/build] Make `GO111MODULE` configurable

### DIFF
--- a/go/build/entrypoint.sh
+++ b/go/build/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-export GO111MODULE=off
+export GO111MODULE=on
 export CGO_ENABLED=0
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
@@ -17,7 +17,6 @@ pwd
 ls
 
 go get -u github.com/mitchellh/gox
-go get -u github.com/golang/dep/cmd/dep
 
 if [[ ! -z "$WORKING_DIR" ]]; then
   mkdir -p "${WORKING_DIR}" || exit 1
@@ -27,5 +26,4 @@ if [[ ! -z "$WORKING_DIR" ]]; then
   ls
 fi
 
-dep ensure
 gox -osarch="${GOX_OSARCH}" -output "${OUTPUT_PATH}{{.OS}}_{{.Arch}}"

--- a/go/build/entrypoint.sh
+++ b/go/build/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-export GO111MODULE=on
+export GO111MODULE="${GO111MODULE:-on}"
 export CGO_ENABLED=0
 export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOBIN
@@ -16,14 +16,19 @@ fi
 pwd
 ls
 
-go get -u github.com/mitchellh/gox
-
 if [[ ! -z "$WORKING_DIR" ]]; then
   mkdir -p "${WORKING_DIR}" || exit 1
   cp -r . "${WORKING_DIR}" || exit 1
   cd "${WORKING_DIR}" || exit 1
   pwd
   ls
+fi
+
+go get -u github.com/mitchellh/gox
+
+if [[ "$GO111MODULE" != "on" ]]; then
+  go get -u github.com/golang/dep/cmd/dep
+  dep ensure
 fi
 
 gox -osarch="${GOX_OSARCH}" -output "${OUTPUT_PATH}{{.OS}}_{{.Arch}}"


### PR DESCRIPTION
## what
* [go/build] Make the variable `GO111MODULE` configurable

## why
* If the action builds a Go solution that uses Go modules, no need to download `dep` and run `dep ensure`
* Make the action compatible with both Go modules (`GO111MODULE=on` - default) and the old `dep` dependency management tool (`GO111MODULE=off`)
