### PR TITLE
Add `rebuld-readme-command` GitHub workflow

### DIFF
--- a/.github/actions.yml
+++ b/.github/actions.yml
@@ -7,5 +7,5 @@ github/create-pull-request: github/create-pull-request/**
 github/git-push: github/git-push/**
 github/release-assets: github/release-assets/**
 github/repository-dispatch: github/repository-dispatch/**
-slash-command-dispatch: github/slash-command-dispatch/**
+github/slash-command-dispatch: github/slash-command-dispatch/**
 go/build: go/build/**

--- a/.github/actions.yml
+++ b/.github/actions.yml
@@ -2,7 +2,10 @@ github/auto-approve: github/auto-approve/**
 github/auto-assign: github/auto-assign/**
 github/auto-merge: github/auto-merge/**
 github/branch-cleanup: github/branch-cleanup/**
+github/create-or-update-comment: github/create-or-update-comment/**
 github/create-pull-request: github/create-pull-request/**
 github/git-push: github/git-push/**
 github/release-assets: github/release-assets/**
+github/repository-dispatch: github/repository-dispatch/**
+slash-command-dispatch: github/slash-command-dispatch/**
 go/build: go/build/**

--- a/.github/workflows/rebuild-readme-command.yml
+++ b/.github/workflows/rebuild-readme-command.yml
@@ -22,21 +22,22 @@ jobs:
           make readme/deps
           make readme
 
-      # Commit changes to the PR branch
+      # Commit changes (if any) to the PR branch
       - name: Commit changes to the PR branch
+        shell: bash
         run: |
           set -x
-          git diff --exit-code
+          output=$(git diff --name-only)
 
-          if [ $? -ne 0 ]; then
-            echo "Changes detected."
+          if [ -n "$output" ]; then
+            echo "Changes detected. Pushing to the PR branch"
             git config --global user.name 'actions-bot'
             git config --global user.email '58130806+actions-bot@users.noreply.github.com'
             git add -A
             git commit -m "Updated README.md"
             git push
           else
-            echo "No changes detected."
+            echo "No changes detected"
           fi
 
       # Add reaction to the original comment

--- a/.github/workflows/rebuild-readme-command.yml
+++ b/.github/workflows/rebuild-readme-command.yml
@@ -1,0 +1,49 @@
+name: Rebuild README
+on:
+  repository_dispatch:
+    types: [rebuild-readme-command]
+
+jobs:
+  rebuild_readme:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the pull request branch
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+      # Rebuild README
+      - name: Rebuild README
+        shell: bash
+        run: |
+          make init
+          make readme/deps
+          make readme
+
+      # Commit changes to the PR branch
+      - name: Commit changes to the PR branch
+        run: |
+          set -x
+          git diff --exit-code
+
+          if [ $? -ne 0 ]; then
+            echo "Changes detected."
+            git config --global user.name 'actions-bot'
+            git config --global user.email '58130806+actions-bot@users.noreply.github.com'
+            git add -A
+            git commit -m "Updated README.md"
+            git push
+          else
+            echo "No changes detected."
+          fi
+
+      # Add reaction to the original comment
+      - name: Add reaction to the original comment
+        uses: cloudposse/actions/github/create-or-update-comment@0.9.0
+        with:
+          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reaction-type: hooray

--- a/github/Makefile
+++ b/github/Makefile
@@ -1,4 +1,4 @@
-all: branch-cleanup auto-approve auto-merge auto-assign create-pull-request
+all: branch-cleanup auto-approve auto-merge auto-assign create-pull-request slash-command-dispatch repository-dispatch create-or-update-comment
 
 clone(%):
 	rm -rf $%


### PR DESCRIPTION
## what
* Add `rebuld-readme-command` GitHub workflow

## why
* Automate rebuilding README in PRs on forks
* `rebuld-readme-command` will be executed in this repo after `/rebuild-readme` slash command dispatch comment is added to a PR in a different repo
* It will rebuild README.md from README.yaml and commit the changes back to the PR repo
