### PR TITLE
Rename `GITHUB_BOT_TOKEN` to `PUBLIC_REPO_ACCESS_TOKEN`

### DIFF
--- a/.github/workflows/pr-opened-command.yml
+++ b/.github/workflows/pr-opened-command.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Pull Request Opened Command
         uses: actions/github-script@0.4.0
         with:
-          github-token: ${{secrets.BOT_TOKEN}}
+          github-token: ${{secrets.PUBLIC_REPO_ACCESS_TOKEN}}
           script: |
 
             const issueNumber = ${{ github.event.client_payload.github.event.pull_request.number }};

--- a/.github/workflows/pr-opened-command.yml
+++ b/.github/workflows/pr-opened-command.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Pull Request Opened Command
         uses: actions/github-script@0.4.0
         with:
-          github-token: ${{secrets.GITHUB_BOT_TOKEN}}
+          github-token: ${{secrets.BOT_TOKEN}}
           script: |
 
             const issueNumber = ${{ github.event.client_payload.github.event.pull_request.number }};

--- a/.github/workflows/rebuild-readme-command.yml
+++ b/.github/workflows/rebuild-readme-command.yml
@@ -10,7 +10,7 @@ jobs:
       # Checkout the pull request branch
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
@@ -44,7 +44,7 @@ jobs:
       - name: Add reaction to the original comment
         uses: cloudposse/actions/github/create-or-update-comment@0.11.0
         with:
-          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray

--- a/.github/workflows/rebuild-readme-command.yml
+++ b/.github/workflows/rebuild-readme-command.yml
@@ -10,7 +10,7 @@ jobs:
       # Checkout the pull request branch
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
@@ -44,7 +44,7 @@ jobs:
       - name: Add reaction to the original comment
         uses: cloudposse/actions/github/create-or-update-comment@0.11.0
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray

--- a/.github/workflows/terraform-fmt-command.yml
+++ b/.github/workflows/terraform-fmt-command.yml
@@ -10,7 +10,7 @@ jobs:
       # Checkout the pull request branch
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
@@ -44,7 +44,7 @@ jobs:
       - name: Add reaction to the original comment
         uses: cloudposse/actions/github/create-or-update-comment@0.11.0
         with:
-          token: ${{ secrets.GITHUB_BOT_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray

--- a/.github/workflows/terraform-fmt-command.yml
+++ b/.github/workflows/terraform-fmt-command.yml
@@ -10,7 +10,7 @@ jobs:
       # Checkout the pull request branch
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
           ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
@@ -44,7 +44,7 @@ jobs:
       - name: Add reaction to the original comment
         uses: cloudposse/actions/github/create-or-update-comment@0.11.0
         with:
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reaction-type: hooray


### PR DESCRIPTION
## what
* Rename `GITHUB_BOT_TOKEN` to `PUBLIC_REPO_ACCESS_TOKEN`

## why
* Secrets names that start with `GITHUB_` are no longer supported by GitHub, throwing the error

```
Failed to add secret. Name is invalid
```

* The new name reflects  that the secret is a GitHub token that requires public repo access scope. It's used to clone forked repos and add comments on PRs on forked repos
