### PR TITLE
pin checkout action to 2.0.0 version

### DIFF
--- a/.github/workflows/rebuild-readme-command.yml
+++ b/.github/workflows/rebuild-readme-command.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout the pull request branch
-      - uses: actions/checkout@v1.2.0
+      - uses: actions/checkout@v2.0.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}

--- a/.github/workflows/terraform-fmt-command.yml
+++ b/.github/workflows/terraform-fmt-command.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout the pull request branch
-      - uses: actions/checkout@v1.2.0
+      - uses: actions/checkout@v2.0.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## what
* pin checkout action to 2.0.0 version

## why
* `v2` tag was moved to 2.1.0 and seems broken. this is to triage if it helps to get it back to normal

## refs
* https://github.com/actions/checkout/releases