### PR TITLE
revert checkout action version to v2 tag

### DIFF
--- a/.github/workflows/rebuild-readme-command.yml
+++ b/.github/workflows/rebuild-readme-command.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout the pull request branch
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v2
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}

--- a/.github/workflows/terraform-fmt-command.yml
+++ b/.github/workflows/terraform-fmt-command.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout the pull request branch
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v2
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## what
* revert checkout action version to v2 tag

## why
*  2.0.0 pinned version was attempt to triage checkout action fails