### PR TITLE
github build and push to github registry

### DIFF
--- a/github/docker-build-and-push/build-and-push.yml
+++ b/github/docker-build-and-push/build-and-push.yml
@@ -1,0 +1,23 @@
+name: docker
+on:
+  push:
+    branches:
+      - master
+  pull_request: 
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+      - name: docker/build-and-push
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          repository: ${{ github.repository }}/default
+          registry: docker.pkg.github.com
+          tag_with_ref: true
+          tag_with_sha: true


### PR DESCRIPTION
## what
Build and push an image to the GitHub docker registry

## why
Easy distribution of docker images

## known limitations

* https://github.community/t/is-it-possible-to-login-to-dockerhub-to-initialize-containers-in-github-actions/16263