### PR TITLE
/test chatops commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,127 @@
+name: test
+on:
+  repository_dispatch:
+    types: [test]
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.client_payload.slash_command.arg1 == "ping" || github.event.client_payload.slash_command.arg1 == "all"}}
+    steps:
+    # Update GitHub status for dispatch events
+    - name: "Update GitHub Status for this ref"
+      #if: ${{ github.event_name == 'repository_dispatch' }}
+      uses: 'docker://cloudposse/github-status-updater'
+      with:
+        # We need to use args because GitHub actions overwrites many `GITHUB_*` environment variables
+        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        GITHUB_STATE: success
+        GITHUB_CONTEXT: 'ping'
+        GITHUB_DESCRIPTION: "pong"
+        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/runs/${{ github.run_id }}
+        GITHUB_OWNER: ${{ github.repository_owner }}
+        GITHUB_REPO: ${{ github.event.client_payload.github.event.repository.name }}
+
+  readme:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.client_payload.slash_command.arg1 == "readme" || github.event.client_payload.slash_command.arg1 == "all" }}
+    container: cloudposse/testing.cloudposse.co:latest
+    env: 
+      PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      MAKE_INCLUDES: Makefile
+    steps:
+
+    # Checkout the code from GitHub Pull Request
+    - name: "Checkout code for ChatOps"
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref }} 
+
+    # Initialize the build-harness with make target helpers
+    - name: "Initialize build-harness"
+      env:
+        BUILD_HARNESS_BRANCH: master
+      run: make init
+
+    # Run the bats tests from the test-harness against the module
+    - name: "Test that README.md was generated from README.yaml"
+      run: make readme/lint
+
+  bats:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.client_payload.slash_command.arg1 == "bats" || github.event.client_payload.slash_command.arg1 == "all" }}
+    container: cloudposse/testing.cloudposse.co:latest
+    env: 
+      PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      MAKE_INCLUDES: Makefile
+    steps:
+
+    # Checkout the code from GitHub Pull Request
+    - name: "Checkout code for ChatOps"
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref }} 
+
+    # Initialize the test-harness which has a library of bats tests
+    - name: "Initialize test-harness"
+      env:
+        TEST_HARNESS_BRANCH: master
+      run: make -C test/ clean init
+
+    # Run the bats tests from the test-harness against the module
+    - name: "Test module with bats"
+      run: make -C test/ module
+
+    # Run the bats tests from the test-harness against the example
+    - name: "Test `examples/complete` with bats"
+      run: make -C test/ examples/complete
+
+  terratest:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.client_payload.slash_command.arg1 == "terratest" || github.event.client_payload.slash_command.arg1 == "all" }}
+    container: cloudposse/testing.cloudposse.co:latest
+    env: 
+      PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      MAKE_INCLUDES: Makefile
+    steps:
+
+    # Checkout the code from GitHub Pull Request
+    - name: "Checkout code for ChatOps"
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref }} 
+
+    # Initialize the terratest go project
+    - name: "Initialize terratest go project"
+      run: make -C test/src clean init
+
+    # Run the terratest integration tests
+    - name: "Test `examples/complete` with terratest"
+      run: make -C test/src
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}  
+
+    # Update GitHub status for dispatch events
+    - name: "Update GitHub Status for this ref"
+      uses: docker://cloudposse/github-status-updater
+      #if: ${{ github.event_name == 'repository_dispatch' }}
+      env:
+        GITHUB_ACTION: update_state
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        GITHUB_STATE: success
+        #GITHUB_CONTEXT: terratest
+        GITHUB_CONTEXT: foobar
+        GITHUB_DESCRIPTION: "terratest passed"
+        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/runs/${{ github.run_id }}
+        GITHUB_OWNER: ${{ github.repository_owner }}
+        GITHUB_REPO: ${{ github.event.client_payload.github.event.repository.name }}
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   repository_dispatch:
-    types: [test]
+    types: [test-command]
 
 jobs:
   ping:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,16 @@ on:
     types: [test-command]
 
 jobs:
+  ack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Add reaction 👍"
+        uses: cloudposse/actions/github/create-or-update-comment@0.15.0
+        with:
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          reaction-type: "+1"
+
   ping:
     runs-on: ubuntu-latest
     if: ${{ github.event.client_payload.slash_command.arg1 == "ping" || github.event.client_payload.slash_command.arg1 == "all"}}


### PR DESCRIPTION
## what
* Add `/test ping` - test github status 
* Add `/test bats` - run bats tests from `test-harness`
* Add `/test terratest` - run `terratest` 
* Add `/test all` - run all tests

## why
* chatops is required to run tests against PRs from forks