### PR TITLE
do not run ping on all

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -17,7 +17,7 @@ jobs:
 
   ping:
     runs-on: ubuntu-latest
-    if: ${{ github.event.client_payload.slash_command.arg1 == 'ping' || github.event.client_payload.slash_command.arg1 == 'all'}}
+    if: ${{ github.event.client_payload.slash_command.arg1 == 'ping' }}
     steps:
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for this ref"


### PR DESCRIPTION
## what
* do not run `ping` on `/test all`

## why
* it's really just for debugging, not testing
