### PR TITLE
support `terraform-github-provider` label

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -258,7 +258,7 @@ jobs:
 
     # Run the terratest integration tests
     - name: "Test `examples/complete` with terratest on AWS & GitHub"
-      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-aws-') && contains(github.event.client_payload.github.payload.repository.name, '-github-')  }}
+      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-aws-') && (contains(github.event.client_payload.github.payload.repository.name, '-github-') || contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-github-provider') ) }}
       run: make -C test/src
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## what
* use `GITHUB_TOKEN` when `terraform-github-provider` label added

## why
* Some terraform module use multiple providers
* Not all providers are evident based on the module name
