### PR TITLE
Use terraform 0.13

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -275,7 +275,15 @@ jobs:
           VERSION=0.13
         fi
 
-        echo "Terraform ${VERSION} is required for ${BASE_REF}..."
+        OVERRIDE_VERSION=$(grep -Eo 'terraform/\d+\.\d+' <<<${LABELS} | cut -d/ -f2)
+
+        if [ -n "${OVERRIDE_VERSION}" ]; then
+          VERSION=${OVERRIDE_VERSION}
+          echo "Terraform ${VERSION} is required based on labels"
+        else
+          echo "Terraform ${VERSION} is required for ${BASE_REF}..."
+        fi
+
         if [ -x "/usr/local/terraform/${VERSION}/bin/terraform" ]; then
           printf "::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ${VERSION}
         else

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -150,18 +150,16 @@ jobs:
     # Determine requied version of terraform based on the target branch of the pull request. Then update the PATH to use it.
     - name: "Determine required terraform version"
       run: |
-        FORMAT="::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        if [[ ${BASE_REF} == 'refs/heads/master' ]]; then
-          echo "Requiring terraform 0.13..."
-          printf $FORMAT 0.13
-        elif [[ ${BASE_REF} == 'refs/heads/0.12/master' ]]; then
-          echo "Requiring terraform 0.12..."
-          printf $FORMAT 0.12
-        elif [[ ${BASE_REF} == 'refs/heads/0.11/master' ]]; then
-          echo "Requiring terraform 0.11..."
-          printf $FORMAT 0.11
+        VERSION=$(cut -d/ -f1 <<<${BASE_REF})
+        if [[ ${VERSION} == 'master' ]]; then
+          VERSION=0.13
+        fi
+
+        echo "Terraform ${VERSION} is required for ${BASE_REF}..."
+        if [ -x "/usr/local/terraform/${VERSION}/bin/terraform" ]; then
+          printf "::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ${VERSION}
         else
-          echo "Unable to determine terraform version for ${BASE_REF}"
+          echo "Unable to locate executable for terraform ${VERSION}"
           exit 1
         fi
       env:
@@ -258,18 +256,16 @@ jobs:
     # Determine requied version of terraform based on the target branch of the pull request. Then update the PATH to use it.
     - name: "Determine required terraform version"
       run: |
-        FORMAT="::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        if [[ ${BASE_REF} == 'refs/heads/master' ]]; then
-          echo "Requiring terraform 0.13..."
-          printf $FORMAT 0.13
-        elif [[ ${BASE_REF} == 'refs/heads/0.12/master' ]]; then
-          echo "Requiring terraform 0.12..."
-          printf $FORMAT 0.12
-        elif [[ ${BASE_REF} == 'refs/heads/0.11/master' ]]; then
-          echo "Requiring terraform 0.11..."
-          printf $FORMAT 0.11
+        VERSION=$(cut -d/ -f1 <<<${BASE_REF})
+        if [[ ${VERSION} == 'master' ]]; then
+          VERSION=0.13
+        fi
+
+        echo "Terraform ${VERSION} is required for ${BASE_REF}..."
+        if [ -x "/usr/local/terraform/${VERSION}/bin/terraform" ]; then
+          printf "::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ${VERSION}
         else
-          echo "Unable to determine terraform version for ${BASE_REF}"
+          echo "Unable to locate executable for terraform ${VERSION}"
           exit 1
         fi
       env:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -157,7 +157,7 @@ jobs:
       run: |
         VERSION=$(cut -d/ -f1 <<<${BASE_REF})
         if [[ ${VERSION} == 'master' ]]; then
-          VERSION=0.13
+          VERSION=0.12
         fi
  
         OVERRIDE_VERSION=$(grep -Eo 'terraform/\d+\.\d+' <<<${LABELS} | cut -d/ -f2)
@@ -272,7 +272,7 @@ jobs:
       run: |
         VERSION=$(cut -d/ -f1 <<<${BASE_REF})
         if [[ ${VERSION} == 'master' ]]; then
-          VERSION=0.13
+          VERSION=0.12
         fi
 
         OVERRIDE_VERSION=$(grep -Eo 'terraform/\d+\.\d+' <<<${LABELS} | cut -d/ -f2)

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -39,7 +39,6 @@ jobs:
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'readme' || github.event.client_payload.slash_command.arg1 == 'readme' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
-      PATH: "/usr/local/terraform/0.13/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
@@ -124,7 +123,6 @@ jobs:
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'bats' || github.event.client_payload.slash_command.arg1 == 'bats' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
-      PATH: "/usr/local/terraform/0.13/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
@@ -148,6 +146,27 @@ jobs:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
         ref: ${{ github.event.client_payload.pull_request.head.ref }} 
+
+    # Determine requied version of terraform based on the target branch of the pull request. Then update the PATH to use it.
+    - name: "Determine required terraform version"
+      run: |
+        FORMAT="::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        if [[ ${GITHUB_REF} == 'refs/heads/master' ]]; then
+          echo "Requiring terraform 0.13..."
+          printf $FORMAT 0.13
+        elif [[ ${GITHUB_REF} == 'refs/heads/0.12/master' ]]; then
+          echo "Requiring terraform 0.12..."
+          printf $FORMAT 0.12
+        elif [[ ${GITHUB_REF} == 'refs/heads/0.11/master' ]]; then
+          echo "Requiring terraform 0.11..."
+          printf $FORMAT 0.11
+        else
+          echo "Unable to determine terraform version for ${GITHUB_REF}"
+          exit 1
+        fi
+      env:
+        # Pull request target branch
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.base.ref }}
 
     # Initialize the test-harness which has a library of bats tests
     - name: "Initialize test-harness"
@@ -212,7 +231,6 @@ jobs:
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'terratest' || github.event.client_payload.slash_command.arg1 == 'terratest' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
-      PATH: "/usr/local/terraform/0.13/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
@@ -236,6 +254,27 @@ jobs:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
         ref: ${{ github.event.client_payload.pull_request.head.ref }} 
+
+    # Determine requied version of terraform based on the target branch of the pull request. Then update the PATH to use it.
+    - name: "Determine required terraform version"
+      run: |
+        FORMAT="::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        if [[ ${GITHUB_REF} == 'refs/heads/master' ]]; then
+          echo "Requiring terraform 0.13..."
+          printf $FORMAT 0.13
+        elif [[ ${GITHUB_REF} == 'refs/heads/0.12/master' ]]; then
+          echo "Requiring terraform 0.12..."
+          printf $FORMAT 0.12
+        elif [[ ${GITHUB_REF} == 'refs/heads/0.11/master' ]]; then
+          echo "Requiring terraform 0.11..."
+          printf $FORMAT 0.11
+        else
+          echo "Unable to determine terraform version for ${GITHUB_REF}"
+          exit 1
+        fi
+      env:
+        # Pull request target branch
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.base.ref }}
 
     # Initialize the terratest go project
     - name: "Initialize terratest go project"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -5,7 +5,8 @@ on:
 
 defaults:
   run:
-    shell: bash
+    # We need -e -o pipefail for consistency with GitHub Actions's default behavior
+    shell: bash -e -o pipefail {0}
 
 jobs:
   ack:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -159,8 +159,16 @@ jobs:
         if [[ ${VERSION} == 'master' ]]; then
           VERSION=0.13
         fi
+ 
+        OVERRIDE_VERSION=$(grep -Eo 'terraform/\d+\.\d+' <<<${LABELS} | cut -d/ -f2)
 
-        echo "Terraform ${VERSION} is required for ${BASE_REF}..."
+        if [ -n "${OVERRIDE_VERSION}" ]; then
+          VERSION=${OVERRIDE_VERSION}
+          echo "Terraform ${VERSION} is required based on labels"
+        else
+          echo "Terraform ${VERSION} is required for ${BASE_REF}..."
+        fi
+
         if [ -x "/usr/local/terraform/${VERSION}/bin/terraform" ]; then
           printf "::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ${VERSION}
         else
@@ -170,6 +178,7 @@ jobs:
       env:
         # Pull request target branch
         BASE_REF: ${{ github.event.client_payload.pull_request.base.ref }}
+        LABELS: ${{ join(github.event.client_payload.pull_request.labels.*.name, '\n') }}
 
     # Initialize the test-harness which has a library of bats tests
     - name: "Initialize test-harness"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -293,6 +293,7 @@ jobs:
       env:
         # Pull request target branch
         BASE_REF: ${{ github.event.client_payload.pull_request.base.ref }}
+        LABELS: ${{ join(github.event.client_payload.pull_request.labels.*.name, '\n') }}
 
     # Initialize the terratest go project
     - name: "Initialize terratest go project"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -159,18 +159,19 @@ jobs:
         if [[ ${VERSION} == 'master' ]]; then
           VERSION=0.12
         fi
- 
-        OVERRIDE_VERSION=$(grep -Eo 'terraform/\d+\.\d+' <<<${LABELS} | cut -d/ -f2)
+
+        # Match lables like `terraform/0.12` or nothing (to prevent non-zero exit code) 
+        OVERRIDE_VERSION=$(grep -Eo '(terraform/\d+\.\d+|)' <<<${LABELS} | cut -d/ -f2)
 
         if [ -n "${OVERRIDE_VERSION}" ]; then
           VERSION=${OVERRIDE_VERSION}
-          echo "Terraform ${VERSION} is required based on labels"
+          echo "Terraform ${VERSION} is required based on labels..."
         else
           echo "Terraform ${VERSION} is required for ${BASE_REF}..."
         fi
 
         if [ -x "/usr/local/terraform/${VERSION}/bin/terraform" ]; then
-          printf "::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ${VERSION}
+          printf "::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n" ${VERSION}
         else
           echo "Unable to locate executable for terraform ${VERSION}"
           exit 1
@@ -275,17 +276,18 @@ jobs:
           VERSION=0.12
         fi
 
-        OVERRIDE_VERSION=$(grep -Eo 'terraform/\d+\.\d+' <<<${LABELS} | cut -d/ -f2)
+        # Match lables like `terraform/0.12` or nothing (to prevent non-zero exit code) 
+        OVERRIDE_VERSION=$(grep -Eo '(terraform/\d+\.\d+|)' <<<${LABELS} | cut -d/ -f2)
 
         if [ -n "${OVERRIDE_VERSION}" ]; then
           VERSION=${OVERRIDE_VERSION}
-          echo "Terraform ${VERSION} is required based on labels"
+          echo "Terraform ${VERSION} is required based on labels..."
         else
           echo "Terraform ${VERSION} is required for ${BASE_REF}..."
         fi
 
         if [ -x "/usr/local/terraform/${VERSION}/bin/terraform" ]; then
-          printf "::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ${VERSION}
+          printf "::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n" ${VERSION}
         else
           echo "Unable to locate executable for terraform ${VERSION}"
           exit 1

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -151,22 +151,22 @@ jobs:
     - name: "Determine required terraform version"
       run: |
         FORMAT="::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        if [[ ${GITHUB_REF} == 'refs/heads/master' ]]; then
+        if [[ ${BASE_REF} == 'refs/heads/master' ]]; then
           echo "Requiring terraform 0.13..."
           printf $FORMAT 0.13
-        elif [[ ${GITHUB_REF} == 'refs/heads/0.12/master' ]]; then
+        elif [[ ${BASE_REF} == 'refs/heads/0.12/master' ]]; then
           echo "Requiring terraform 0.12..."
           printf $FORMAT 0.12
-        elif [[ ${GITHUB_REF} == 'refs/heads/0.11/master' ]]; then
+        elif [[ ${BASE_REF} == 'refs/heads/0.11/master' ]]; then
           echo "Requiring terraform 0.11..."
           printf $FORMAT 0.11
         else
-          echo "Unable to determine terraform version for ${GITHUB_REF}"
+          echo "Unable to determine terraform version for ${BASE_REF}"
           exit 1
         fi
       env:
         # Pull request target branch
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.base.ref }}
+        BASE_REF: ${{ github.event.client_payload.pull_request.base.ref }}
 
     # Initialize the test-harness which has a library of bats tests
     - name: "Initialize test-harness"
@@ -259,22 +259,22 @@ jobs:
     - name: "Determine required terraform version"
       run: |
         FORMAT="::set-env name=PATH::/usr/local/terraform/%s/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        if [[ ${GITHUB_REF} == 'refs/heads/master' ]]; then
+        if [[ ${BASE_REF} == 'refs/heads/master' ]]; then
           echo "Requiring terraform 0.13..."
           printf $FORMAT 0.13
-        elif [[ ${GITHUB_REF} == 'refs/heads/0.12/master' ]]; then
+        elif [[ ${BASE_REF} == 'refs/heads/0.12/master' ]]; then
           echo "Requiring terraform 0.12..."
           printf $FORMAT 0.12
-        elif [[ ${GITHUB_REF} == 'refs/heads/0.11/master' ]]; then
+        elif [[ ${BASE_REF} == 'refs/heads/0.11/master' ]]; then
           echo "Requiring terraform 0.11..."
           printf $FORMAT 0.11
         else
-          echo "Unable to determine terraform version for ${GITHUB_REF}"
+          echo "Unable to determine terraform version for ${BASE_REF}"
           exit 1
         fi
       env:
         # Pull request target branch
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.base.ref }}
+        BASE_REF: ${{ github.event.client_payload.pull_request.base.ref }}
 
     # Initialize the terratest go project
     - name: "Initialize terratest go project"

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'readme' || github.event.client_payload.slash_command.arg1 == 'readme' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
-      PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      PATH: "/usr/local/terraform/0.13/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
@@ -124,7 +124,7 @@ jobs:
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'bats' || github.event.client_payload.slash_command.arg1 == 'bats' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
-      PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      PATH: "/usr/local/terraform/0.13/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
@@ -212,7 +212,7 @@ jobs:
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'terratest' || github.event.client_payload.slash_command.arg1 == 'terratest' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
-      PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      PATH: "/usr/local/terraform/0.13/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -3,6 +3,10 @@ on:
   repository_dispatch:
     types: [test-command]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   ack:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## what
* Use terraform 0.13 for tests
* Support specifying `terraform/0.12` and `terraform/0.13` labels to explicitly test using that minor version of terraform
* Support automatically using appropriate terraform version for hotfix branches (E.g. `0.12/master`)
* Default to 0.12 (for now) on `master`

## why
* Latest release