### PR TITLE
support new arg format for slash-command-dispatch

### DIFF
--- a/.github/workflows/terraform-fmt-command.yml
+++ b/.github/workflows/terraform-fmt-command.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
         run: |
           make init
-          make terraform/install TERRAFORM_VERSION=0.12.19
+          make terraform/install TERRAFORM_VERSION=0.12.29
           terraform fmt -recursive
 
       # Commit changes (if any) to the PR branch

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -17,7 +17,7 @@ jobs:
 
   ping:
     runs-on: ubuntu-latest
-    if: ${{ github.event.client_payload.slash_command.arg1 == 'ping' }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'ping' || github.event.client_payload.slash_command.arg1 == 'ping' }}
     steps:
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for this ref"
@@ -36,7 +36,7 @@ jobs:
 
   readme:
     runs-on: ubuntu-latest
-    if: ${{ github.event.client_payload.slash_command.arg1 == 'readme' || github.event.client_payload.slash_command.arg1 == 'all' }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'readme' || github.event.client_payload.slash_command.arg1 == 'readme' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
       PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -121,7 +121,7 @@ jobs:
 
   bats:
     runs-on: ubuntu-latest
-    if: ${{ github.event.client_payload.slash_command.arg1 == 'bats' || github.event.client_payload.slash_command.arg1 == 'all' }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'bats' || github.event.client_payload.slash_command.arg1 == 'bats' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
       PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -209,7 +209,7 @@ jobs:
 
   terratest:
     runs-on: ubuntu-latest
-    if: ${{ github.event.client_payload.slash_command.arg1 == 'terratest' || github.event.client_payload.slash_command.arg1 == 'all' }}
+    if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'terratest' || github.event.client_payload.slash_command.arg1 == 'terratest' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
     env: 
       PATH: "/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
## what
* Support old and new payloads for slash-command-dispatch

## why

* #48 changed the way args are args are passed due to [upstream refactoring](https://github.com/peter-evans/slash-command-dispatch/commit/0849c83c5c10c4c9e4c6e3ebfb10b50b5c48132e#diff-04c6e90faac2675aa89e2176d2eec7d8R161)