### PR TITLE
Include terratest for `terraform-null-*` repos

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -256,7 +256,6 @@ jobs:
 
     # Run the terratest integration tests with only GitHub credentials
     - name: "Test `examples/complete` with terratest on GitHub"
-      # Add terraform-null-label explicitly, as the other terraform-null- repos do not yet have tests
       if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-github-') }}
       run: make -C test/src
       env:

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -243,8 +243,7 @@ jobs:
 
     # Run the terratest integration tests without credentials
     - name: "Test `examples/complete` with terratest locally, without credentials"
-      # Add terraform-null-label explicitly, as the other terraform-null- repos do not yet have tests
-      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-null-label') }}
+      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-null-') }}
       run: make -C test/src
 
     # Run the terratest integration tests with only AWS credentials

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -251,7 +251,8 @@ jobs:
 
     # Run the terratest integration tests
     - name: "Test `examples/complete` with terratest on GitHub"
-      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-github-') }}
+      # Add terraform-null-label explicitly, as the other terraform-null- repos do not yet have tests
+      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-github-') || contains(github.event.client_payload.github.payload.repository.name, 'terraform-null-label') }}
       run: make -C test/src
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -241,7 +241,13 @@ jobs:
     - name: "Initialize terratest go project"
       run: make -C test/src clean init
 
-    # Run the terratest integration tests
+    # Run the terratest integration tests without credentials
+    - name: "Test `examples/complete` with terratest locally, without credentials"
+      # Add terraform-null-label explicitly, as the other terraform-null- repos do not yet have tests
+      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-null-label') }}
+      run: make -C test/src
+
+    # Run the terratest integration tests with only AWS credentials
     - name: "Test `examples/complete` with terratest on AWS"
       if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-aws-') && !( contains(github.event.client_payload.github.payload.repository.name, '-github-') || contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-github-provider') ) }}
       run: make -C test/src
@@ -249,22 +255,22 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
-    # Run the terratest integration tests
+    # Run the terratest integration tests with only GitHub credentials
     - name: "Test `examples/complete` with terratest on GitHub"
       # Add terraform-null-label explicitly, as the other terraform-null- repos do not yet have tests
-      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-github-') || contains(github.event.client_payload.github.payload.repository.name, 'terraform-null-label') }}
+      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-github-') }}
       run: make -C test/src
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
 
-    # Run the terratest integration tests
+    # Run the terratest integration tests with only Opsgenie credentials
     - name: "Test `examples/complete` with terratest on Opsgenie"
       if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-opsgenie-') }}
       run: make -C test/src
       env:
         OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
 
-    # Run the terratest integration tests
+    # Run the terratest integration tests with both AWS and GitHub credentials
     - name: "Test `examples/complete` with terratest on AWS & GitHub"
       if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-aws-') && ( contains(github.event.client_payload.github.payload.repository.name, '-github-') || contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-github-provider') ) }}
       run: make -C test/src


### PR DESCRIPTION
## what
- Include terratest for `terraform-null-label`

## why
- Terratest is set up to be explicitly enabled by repo name, and `terraform-null-label` was not included
- Include only `terraform-null-label` not all `terraform-null-` repos for now as no other repos have tests