### PR TITLE
Add GitHub Actions job to test on AWS & Datadog

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'readme' || github.event.client_payload.slash_command.arg1 == 'readme' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
-    env: 
+    env:
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
@@ -57,7 +57,7 @@ jobs:
         GITHUB_CONTEXT: "test/readme"
         GITHUB_DESCRIPTION: "tests started by @${{ github.event.client_payload.github.actor }}"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
 
@@ -67,7 +67,7 @@ jobs:
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.client_payload.pull_request.head.ref }} 
+        ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
     # Initialize the build-harness with make target helpers
     - name: "Initialize build-harness"
@@ -91,7 +91,7 @@ jobs:
         GITHUB_CONTEXT: "test/readme"
         GITHUB_DESCRIPTION: "tests failed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
@@ -105,7 +105,7 @@ jobs:
         GITHUB_CONTEXT: "test/readme"
         GITHUB_DESCRIPTION: "tests passed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
@@ -120,14 +120,14 @@ jobs:
         GITHUB_CONTEXT: "test/readme"
         GITHUB_DESCRIPTION: "tests cancelled"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
   bats:
     runs-on: ubuntu-latest
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'bats' || github.event.client_payload.slash_command.arg1 == 'bats' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
-    env: 
+    env:
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
@@ -141,7 +141,7 @@ jobs:
         GITHUB_CONTEXT: "test/bats"
         GITHUB_DESCRIPTION: "tests started by @${{ github.event.client_payload.github.actor }}"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Checkout the code from GitHub Pull Request
@@ -150,7 +150,7 @@ jobs:
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.client_payload.pull_request.head.ref }} 
+        ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
     # Determine requied version of terraform based on the target branch of the pull request. Then update the PATH to use it.
     - name: "Determine required terraform version"
@@ -160,7 +160,7 @@ jobs:
           VERSION=0.12
         fi
 
-        # Match lables like `terraform/0.12` or nothing (to prevent non-zero exit code) 
+        # Match lables like `terraform/0.12` or nothing (to prevent non-zero exit code)
         OVERRIDE_VERSION=$(grep -Eo '(terraform/\d+\.\d+|)' <<<${LABELS} | cut -d/ -f2)
 
         if [ -n "${OVERRIDE_VERSION}" ]; then
@@ -207,7 +207,7 @@ jobs:
         GITHUB_CONTEXT: "test/bats"
         GITHUB_DESCRIPTION: "tests failed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
@@ -221,7 +221,7 @@ jobs:
         GITHUB_CONTEXT: "test/bats"
         GITHUB_DESCRIPTION: "tests passed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
@@ -236,14 +236,14 @@ jobs:
         GITHUB_CONTEXT: "test/bats"
         GITHUB_DESCRIPTION: "tests cancelled"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
   terratest:
     runs-on: ubuntu-latest
     if: ${{ github.event.client_payload.slash_command.args.unnamed.arg1 == 'terratest' || github.event.client_payload.slash_command.arg1 == 'terratest' || github.event.client_payload.slash_command.args.unnamed.arg1 == 'all' || github.event.client_payload.slash_command.arg1 == 'all' }}
     container: cloudposse/testing.cloudposse.co:latest
-    env: 
+    env:
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
@@ -257,7 +257,7 @@ jobs:
         GITHUB_CONTEXT: "test/terratest"
         GITHUB_DESCRIPTION: "tests started by @${{ github.event.client_payload.github.actor }}"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Checkout the code from GitHub Pull Request
@@ -266,7 +266,7 @@ jobs:
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
-        ref: ${{ github.event.client_payload.pull_request.head.ref }} 
+        ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
     # Determine requied version of terraform based on the target branch of the pull request. Then update the PATH to use it.
     - name: "Determine required terraform version"
@@ -276,7 +276,7 @@ jobs:
           VERSION=0.12
         fi
 
-        # Match lables like `terraform/0.12` or nothing (to prevent non-zero exit code) 
+        # Match lables like `terraform/0.12` or nothing (to prevent non-zero exit code)
         OVERRIDE_VERSION=$(grep -Eo '(terraform/\d+\.\d+|)' <<<${LABELS} | cut -d/ -f2)
 
         if [ -n "${OVERRIDE_VERSION}" ]; then
@@ -298,7 +298,7 @@ jobs:
         LABELS: ${{ join(github.event.client_payload.pull_request.labels.*.name, '\n') }}
 
     # Initialize the terratest go project
-    - name: "Initialize terratest go project"
+    - name: "Initialize terratest Go project"
       run: make -C test/src clean init
 
     # Run the terratest integration tests without credentials
@@ -308,7 +308,7 @@ jobs:
 
     # Run the terratest integration tests with only AWS credentials
     - name: "Test `examples/complete` with terratest on AWS"
-      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-aws-') && !( contains(github.event.client_payload.github.payload.repository.name, '-github-') || contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-github-provider') ) }}
+      if: ${{ contains(github.event.client_payload.github.payload.repository.name, 'terraform-aws-') && !( contains(github.event.client_payload.github.payload.repository.name, '-github-') || contains(github.event.client_payload.github.payload.repository.name, '-datadog-') || contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-github-provider') || contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-datadog-provider') ) }}
       run: make -C test/src
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -334,8 +334,18 @@ jobs:
       run: make -C test/src
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}  
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+
+      # Run the terratest integration tests with both AWS and Datadog credentials
+    - name: "Test `examples/complete` with terratest on AWS & Datadog"
+      if: ${{ contains(github.event.client_payload.github.payload.repository.name, '-datadog-') || contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-datadog-provider') }}
+      run: make -C test/src
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
 
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for failure"
@@ -349,7 +359,7 @@ jobs:
         GITHUB_CONTEXT: "test/terratest"
         GITHUB_DESCRIPTION: "tests failed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
@@ -363,7 +373,7 @@ jobs:
         GITHUB_CONTEXT: "test/terratest"
         GITHUB_DESCRIPTION: "tests passed"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
@@ -378,6 +388,6 @@ jobs:
         GITHUB_CONTEXT: "test/terratest"
         GITHUB_DESCRIPTION: "tests cancelled"
         GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }} 
+        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
         GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,3 @@ labeler:
 	for action in $(ACTIONS); do \
 		echo "$${action%/}: $${action}**"; \
 	done > .github/actions.yml
-
-


### PR DESCRIPTION
## what
* Add GitHub Actions job to test on AWS & Datadog

## why
* We have repos that require provisioning Datadog resources that need DD credentials
* In the new job, we use ENV variables `DD_API_KEY ` and `DD_APP_KEY` to specify `api_key` and `app_key` to the Datadog terraform provider 