### PR TITLE
Disable Renovate npm manager

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "npm": {
+    "enabled": false
+  }
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## what
- Disable the `npm` manager in Renovate for this repo

## why
- We are not maintaining the JavaScript based actions in this repository, we are only mirroring them for stability and never want to change them

## note

If at some point we do create JavaScript based actions that we want to maintain, we can enable the manager and restrict which `package.json` files it looks at via [fileMatch](https://docs.renovatebot.com/modules/manager/#file-matching)