### PR TITLE
Fix Terraform version check

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -154,6 +154,7 @@ jobs:
 
     # Determine requied version of terraform based on the target branch of the pull request. Then update the PATH to use it.
     - name: "Determine required terraform version"
+      shell: bash -x -e -o pipefail {0}
       run: |
         VERSION=$(cut -d/ -f1 <<<${BASE_REF})
         if [[ ${VERSION} == 'master' ]]; then
@@ -276,6 +277,7 @@ jobs:
 
     # Determine requied version of terraform based on the target branch of the pull request. Then update the PATH to use it.
     - name: "Determine required terraform version"
+      shell: bash -x -e -o pipefail {0}
       run: |
         VERSION=$(cut -d/ -f1 <<<${BASE_REF})
         if [[ ${VERSION} == 'master' ]]; then

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -161,7 +161,8 @@ jobs:
           TF12=0.12.29
           TF13=$(terraform-0.13 version --json | jq -r .terraform_version)
           TF14=$(terraform-0.14 version --json | jq -r .terraform_version)
-          VERSION=$(vert -s "$(terraform-config-inspect --json . | jq -r '.required_core[]')" "$TF12" "$TF13" "$TF14" | head -1)
+          # vert exits non-zero if any of the versions are not acceptable, so `|| [[ -n "$VERSION" ]]` for a real error check
+          VERSION=$(vert -s "$(terraform-config-inspect --json . | jq -r '.required_core[]')" "$TF12" "$TF13" "$TF14" | head -1) || [[ -n "$VERSION" ]]
           echo Full version to use is ${VERSION}, setting to ${VERSION:0:4}
           VERSION=${VERSION:0:4}
         fi
@@ -284,7 +285,8 @@ jobs:
           TF12=0.12.29
           TF13=$(terraform-0.13 version --json | jq -r .terraform_version)
           TF14=$(terraform-0.14 version --json | jq -r .terraform_version)
-          VERSION=$(vert -s "$(terraform-config-inspect --json . | jq -r '.required_core[]')" "$TF12" "$TF13" "$TF14" | head -1)
+          # vert exits non-zero if any of the versions are not acceptable, so `|| [[ -n "$VERSION" ]]` for a real error check
+          VERSION=$(vert -s "$(terraform-config-inspect --json . | jq -r '.required_core[]')" "$TF12" "$TF13" "$TF14" | head -1) || [[ -n "$VERSION" ]]
           echo Full version to use is ${VERSION}, setting to ${VERSION:0:4}
           VERSION=${VERSION:0:4}
         fi


### PR DESCRIPTION
## what
- Fix Terraform version check

## why
- Was failing when we did not want it to fail due to `vert`'s definition of failure