### PR TITLE
[test-command] Restore `slash-command` v2 support broken by #85

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -22,7 +22,7 @@ jobs:
       id: parse
       env:
         DEBUG: ${{ toJSON(github.event.client_payload.slash_command) }}
-        ARGS_V1: ${{ github.event.client_payload.slash_command.args }}
+        ARGS_V1: ${{ github.event.client_payload.slash_command.arg1 }}
         ARGS_V2: ${{ github.event.client_payload.slash_command.args.unnamed.all }}
       shell: bash
       run: |


### PR DESCRIPTION
## what
- [test-command] Restore `slash-command` v2 support broken by #85

## why
- With #85, V2 payload interpreted as V1 broke entire workflow 