### PR TITLE
Adding terratest support for Terraform Cloud

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -384,6 +384,9 @@ jobs:
         USES_DATADOG: >-
           ${{ contains(github.event.client_payload.github.payload.repository.name, '-datadog-')
           ||  contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-datadog-provider') }}
+        USES_TFE: >-
+          ${{ contains(github.event.client_payload.github.payload.repository.name, '-tfe-')
+          ||  contains(github.event.client_payload.pull_request.labels.*.name, 'terraform-tfe-provider') }}
 
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_KEY:    ${{ secrets.AWS_SECRET_KEY }}
@@ -393,6 +396,7 @@ jobs:
         DD_APP_KEY:        ${{ secrets.DD_APP_KEY }}
         SPOTINST_TOKEN:    ${{ secrets.SPOTINST_TOKEN }}
         SPOTINST_ACCOUNT:  ${{ secrets.SPOTINST_ACCOUNT }}
+        TFE_TOKEN:         ${{ secrets.TFE_TOKEN }}
       shell: bash
       run: |
         if [[ "$USES_AWS" == "true" || "$USES_DATADOG" == "true" || "$USES_SPOTINST" == "true" ]]; then
@@ -417,6 +421,10 @@ jobs:
           printf "%s=%s\n"  SPOTINST_TOKEN   "$SPOTINST_TOKEN"   >> "$GITHUB_ENV"
           printf "%s=%s\n"  SPOTINST_ACCOUNT "$SPOTINST_ACCOUNT" >> "$GITHUB_ENV"
           echo exported Spotinst
+        fi
+        if [[ "$USES_TFE" == "true" ]]; then
+          printf "%s=%s\n"  TFE_TOKEN   "$TFE_TOKEN"   >> "$GITHUB_ENV"
+          echo exported Terraform Cloud
         fi
 
     - name: "Test `examples/complete` with terratest"


### PR DESCRIPTION
# what & why?

- Adding support for the Terraform `tfe` (Terraform Enterprise/Cloud) provider
- Adding support for `TFE_TOKEN` secret
- Required to run our terratest for `terraform-tfe-cloud-infrastructure-automation`