### PR TITLE
Update Codefresh `pipeline-creator`

### DIFF
--- a/codefresh/pipeline-creator/README.md
+++ b/codefresh/pipeline-creator/README.md
@@ -24,26 +24,25 @@ jobs:
   pipeline-creator:
     runs-on: ubuntu-latest
     steps:
-      - uses: cloudposse/actions/codefresh/pipeline-creator@master
+      - uses: cloudposse/actions/codefresh/pipeline-creator@0.25.0
         with:
           # GitHub owner and repository name of the application repository
           repo: "${{ github.repository }}"
-          # Codefresh project name to host the pipelines (corresponds to GitHub repository name)
-          cf_project: "${{  github.event.repository.name  }}"
+          # Codefresh project name to host the pipelines
+          cf_project: "${{ github.event.repository.name }}"
           # URL of the repository that contains Codefresh pipelines and pipeline specs
-          cf_repo_url: 'https://github.com/my-company/codefresh.git'
-          # Name of the repository that contains Codefresh pipelines and pipeline specs
-          cf_repo_name: "codefresh"
+          cf_repo_url: "https://github.com/AltaisCorp/codefresh.git"
           # Version of the repository that contains Codefresh pipelines and pipeline specs
-          cf_repo_version: "main"
-          # Relative path to the pipeline specs catalog in the Codefresh repository
-          cf_spec_catalog: "specs/microservice"
-          # Relative path to the pipelines catalog in the Codefresh repository
-          cf_pipeline_catalog: "pipelines/microservice"
+          cf_repo_version: "0.1.0"
+          # Pipeline spec type (microservice, spa, serverless)
+          cf_spec_type: "microservice"
           # A comma separated list of pipeline specs to create the pipelines from
           cf_specs: "preview,build,deploy,release,destroy"
-          # Codefresh API Key from global organization secret
-          cf_api_key: "${{ secrets.CF_API_KEY }}"
+        env:
+          GITHUB_USER: "xxxxxxxxx-bot"
+          # Global organization secrets
+          GITHUB_TOKEN: "${{ secrets.CF_GITHUB_PAT }}"
+          CF_API_KEY: "${{ secrets.CF_API_KEY }}"
 ```
 
 

--- a/codefresh/pipeline-creator/action.yml
+++ b/codefresh/pipeline-creator/action.yml
@@ -17,21 +17,12 @@ inputs:
   cf_repo_url:
     description: 'URL of the repository that contains Codefresh pipelines and pipeline specs.'
     required: true
-  cf_repo_name:
-    description: 'Name of the repository that contains Codefresh pipelines and pipeline specs.'
-    required: true
   cf_repo_version:
     description: 'Version of the repository that contains Codefresh pipelines and pipeline specs.'
     required: true
-  cf_spec_catalog:
-    description: 'Relative path to the pipeline specs catalog in the Codefresh repository.'
-    required: true
-  cf_pipeline_catalog:
-    description: 'Relative path to the pipelines catalog in the Codefresh repository.'
+  cf_spec_type:
+    description: 'Pipeline spec type (microservice, spa, serverless).'
     required: true
   cf_specs:
     description: 'A comma separated list of pipeline specs to create the pipelines from.'
-    required: true
-  cf_api_key:
-    description: 'Codefresh API Key.'
     required: true

--- a/codefresh/pipeline-creator/entrypoint.sh
+++ b/codefresh/pipeline-creator/entrypoint.sh
@@ -15,10 +15,10 @@ echo "Cloning repo ${INPUT_CF_REPO_URL} version ${INPUT_CF_REPO_VERSION}"
 git clone -c advice.detachedHead=false --depth=1 -b "${INPUT_CF_REPO_VERSION}" "${INPUT_CF_REPO_URL}" codefresh
 cd ./codefresh
 
-codefresh auth create-context --api-key "${CF_API_KEY}"
+# codefresh auth create-context --api-key "${CF_API_KEY}"
 
 for spec in $(tr , ' ' <<<"${INPUT_CF_SPECS}"); do
-  echo "Updating ${spec} spec"
+  echo "Updating ${spec} pipeline"
   input_pipeline_file=./"${INPUT_CF_PIPELINE_CATALOG}"/"${spec}".yaml
   input_spec_file=./"${INPUT_CF_SPEC_CATALOG}"/"${spec}".yaml
   output_file=./"${INPUT_CF_SPEC_CATALOG}"/"${spec}"-rendered.yaml

--- a/codefresh/pipeline-creator/entrypoint.sh
+++ b/codefresh/pipeline-creator/entrypoint.sh
@@ -6,7 +6,6 @@ export PROJECT="${INPUT_CF_PROJECT}"
 export REPO="${INPUT_REPO}"
 
 NETRC="$HOME/.netrc"
-
 printf "machine github.com\n" > "$NETRC"
 printf "login %s\n" "$GITHUB_USER" >> "$NETRC"
 printf "password %s\n" "$GITHUB_TOKEN" >> "$NETRC"
@@ -17,9 +16,9 @@ cd ./codefresh
 
 for spec in $(tr , ' ' <<<"${INPUT_CF_SPECS}"); do
   echo "Updating '${spec}' pipeline..."
-  input_pipeline_file=./"${INPUT_CF_PIPELINE_CATALOG}"/"${spec}".yaml
-  input_spec_file=./"${INPUT_CF_SPEC_CATALOG}"/"${spec}".yaml
-  output_file=./"${INPUT_CF_SPEC_CATALOG}"/"${spec}"-rendered.yaml
+  input_pipeline_file=./pipelines/"${INPUT_CF_SPEC_TYPE}"/"${spec}".yaml
+  input_spec_file=./specs/"${INPUT_CF_SPEC_TYPE}"/"${spec}".yaml
+  output_file=./specs/"${INPUT_CF_SPEC_TYPE}"/"${spec}"-rendered.yaml
   gomplate -d pipeline="$input_pipeline_file" -f "$input_spec_file" -o "$output_file"
   codefresh get project "${INPUT_CF_PROJECT}" || codefresh create project "${INPUT_CF_PROJECT}"
   codefresh replace pipeline -f "$output_file" || codefresh create pipeline -f "$output_file"

--- a/codefresh/pipeline-creator/entrypoint.sh
+++ b/codefresh/pipeline-creator/entrypoint.sh
@@ -15,10 +15,8 @@ echo "Cloning repo ${INPUT_CF_REPO_URL} version ${INPUT_CF_REPO_VERSION}"
 git clone -c advice.detachedHead=false --depth=1 -b "${INPUT_CF_REPO_VERSION}" "${INPUT_CF_REPO_URL}" codefresh
 cd ./codefresh
 
-# codefresh auth create-context --api-key "${CF_API_KEY}"
-
 for spec in $(tr , ' ' <<<"${INPUT_CF_SPECS}"); do
-  echo "Updating ${spec} pipeline"
+  echo "Updating '${spec}' pipeline..."
   input_pipeline_file=./"${INPUT_CF_PIPELINE_CATALOG}"/"${spec}".yaml
   input_spec_file=./"${INPUT_CF_SPEC_CATALOG}"/"${spec}".yaml
   output_file=./"${INPUT_CF_SPEC_CATALOG}"/"${spec}"-rendered.yaml

--- a/codefresh/pipeline-creator/entrypoint.sh
+++ b/codefresh/pipeline-creator/entrypoint.sh
@@ -5,14 +5,23 @@ set -e -o pipefail
 export PROJECT="${INPUT_CF_PROJECT}"
 export REPO="${INPUT_REPO}"
 
+NETRC="$HOME/.netrc"
+
+printf "machine github.com" > $NETRC
+printf "login %s" "$GITHUB_USER" >> $NETRC
+printf "password %s" "$GITHUB_TOKEN" >> $NETRC
+
+echo "Cloning repo from ${INPUT_CF_REPO_URL}"
 git clone "${INPUT_CF_REPO_URL}"
 cd "${INPUT_CF_REPO_NAME}"
+
+echo "Checking out ${INPUT_CF_VERSION}"
 git checkout "${INPUT_CF_VERSION}"
 
-codefresh auth create-context context --api-key "$INPUT_CF_API_KEY"
-codefresh auth use-contex context
+codefresh auth create-context
 
 for spec in $(tr , ' ' <<<"${INPUT_CF_SPECS}"); do
+  echo "Updating ${spec} spec"
   input_pipeline_file=./"${INPUT_CF_PIPELINE_CATALOG}"/"${spec}".yaml
   input_spec_file=./"${INPUT_CF_SPEC_CATALOG}"/"${spec}".yaml
   output_file=./"${INPUT_CF_SPEC_CATALOG}"/"${spec}"-rendered.yaml

--- a/codefresh/pipeline-creator/entrypoint.sh
+++ b/codefresh/pipeline-creator/entrypoint.sh
@@ -15,7 +15,7 @@ echo "Cloning repo ${INPUT_CF_REPO_URL} version ${INPUT_CF_REPO_VERSION}"
 git clone -c advice.detachedHead=false --depth=1 -b "${INPUT_CF_REPO_VERSION}" "${INPUT_CF_REPO_URL}" codefresh
 cd ./codefresh
 
-codefresh auth create-context
+codefresh auth create-context --api-key "${CF_API_KEY}"
 
 for spec in $(tr , ' ' <<<"${INPUT_CF_SPECS}"); do
   echo "Updating ${spec} spec"

--- a/codefresh/pipeline-creator/entrypoint.sh
+++ b/codefresh/pipeline-creator/entrypoint.sh
@@ -12,11 +12,11 @@ printf "login %s\n" "$GITHUB_USER" >> "$NETRC"
 printf "password %s\n" "$GITHUB_TOKEN" >> "$NETRC"
 
 echo "Cloning repo from ${INPUT_CF_REPO_URL}"
-git clone "${INPUT_CF_REPO_URL}"
-cd "${INPUT_CF_REPO_NAME}"
+git clone "${INPUT_CF_REPO_URL}" codefresh
+cd ./codefresh
 
-echo "Checking out ${INPUT_CF_VERSION}"
-git checkout "${INPUT_CF_VERSION}"
+echo "Checking out ${INPUT_CF_REPO_VERSION}"
+git checkout "${INPUT_CF_REPO_VERSION}"
 
 codefresh auth create-context
 

--- a/codefresh/pipeline-creator/entrypoint.sh
+++ b/codefresh/pipeline-creator/entrypoint.sh
@@ -11,12 +11,9 @@ printf "machine github.com\n" > "$NETRC"
 printf "login %s\n" "$GITHUB_USER" >> "$NETRC"
 printf "password %s\n" "$GITHUB_TOKEN" >> "$NETRC"
 
-echo "Cloning repo from ${INPUT_CF_REPO_URL}"
-git clone "${INPUT_CF_REPO_URL}" codefresh
+echo "Cloning repo ${INPUT_CF_REPO_URL} version ${INPUT_CF_REPO_VERSION}"
+git clone -c advice.detachedHead=false --depth=1 -b "${INPUT_CF_REPO_VERSION}" "${INPUT_CF_REPO_URL}" codefresh
 cd ./codefresh
-
-echo "Checking out ${INPUT_CF_REPO_VERSION}"
-git checkout "${INPUT_CF_REPO_VERSION}"
 
 codefresh auth create-context
 

--- a/codefresh/pipeline-creator/entrypoint.sh
+++ b/codefresh/pipeline-creator/entrypoint.sh
@@ -7,9 +7,9 @@ export REPO="${INPUT_REPO}"
 
 NETRC="$HOME/.netrc"
 
-printf "machine github.com" > $NETRC
-printf "login %s" "$GITHUB_USER" >> $NETRC
-printf "password %s" "$GITHUB_TOKEN" >> $NETRC
+printf "machine github.com\n" > "$NETRC"
+printf "login %s\n" "$GITHUB_USER" >> "$NETRC"
+printf "password %s\n" "$GITHUB_TOKEN" >> "$NETRC"
 
 echo "Cloning repo from ${INPUT_CF_REPO_URL}"
 git clone "${INPUT_CF_REPO_URL}"


### PR DESCRIPTION
## what
* Update Codefresh `pipeline-creator`

## why
* Use `cf_spec_type` to provide pipeline spec type (microservice, spa, serverless) instead of defining `cf_spec_catalog` and `cf_pipeline_catalog` as paths to the pipeline definitions and specs - simpler, but more opinionated, configuration.
* Use `netrc` to provide `GITHUB_TOKEN` to `git clone` - more secure.
