### PR TITLE
Select Terraform version via versions.tf

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -8,7 +8,7 @@ jobs:
     name: Auto delete branch on merge
     runs-on: ubuntu-latest
     steps:
-    - uses: cloudposse/actions/github/branch-cleanup@0.22.0
+    - uses: cloudposse/actions/github/branch-cleanup@0.28.0
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         NO_BRANCH_DELETED_EXIT_CODE: 0

--- a/.github/workflows/rebuild-readme-command.yml
+++ b/.github/workflows/rebuild-readme-command.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Add reaction to the original comment
       - name: Add reaction to the original comment
-        uses: cloudposse/actions/github/create-or-update-comment@0.22.0
+        uses: cloudposse/actions/github/create-or-update-comment@0.28.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/terraform-fmt-command.yml
+++ b/.github/workflows/terraform-fmt-command.yml
@@ -40,7 +40,7 @@ jobs:
 
       # Add reaction to the original comment
       - name: Add reaction to the original comment
-        uses: cloudposse/actions/github/create-or-update-comment@0.22.0
+        uses: cloudposse/actions/github/create-or-update-comment@0.28.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -59,7 +59,7 @@ jobs:
     if: github.event.client_payload.github.payload.comment.id != ''
     steps:
       - name: "Add reaction 👍👎️"
-        uses: cloudposse/actions/github/create-or-update-comment@0.22.0
+        uses: cloudposse/actions/github/create-or-update-comment@0.28.0
         with:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -206,9 +206,10 @@ jobs:
     - name: "Determine required terraform version"
       shell: bash -x -e -o pipefail {0}
       run: |
+        # Some legacy support is on 0.11 branches and we determine the Terraform version based on the target branch name
         VERSION=$(cut -d/ -f1 <<<${BASE_REF})
-        if [[ ${VERSION} == 'master' ]]; then
-          TF12=0.12.29
+        if [[ ${VERSION} != '0.11' ]]; then
+          TF12=0.12.30
           TF13=$(terraform-0.13 version --json | jq -r .terraform_version)
           TF14=$(terraform-0.14 version --json | jq -r .terraform_version)
           # vert exits non-zero if any of the versions are not acceptable, so `|| [[ -n "$VERSION" ]]` for a real error check
@@ -331,9 +332,10 @@ jobs:
     - name: "Determine required terraform version"
       shell: bash -x -e -o pipefail {0}
       run: |
+        # Some legacy support is on 0.11 branches and we determine the Terraform version based on the target branch name
         VERSION=$(cut -d/ -f1 <<<${BASE_REF})
-        if [[ ${VERSION} == 'master' ]]; then
-          TF12=0.12.29
+        if [[ ${VERSION} != '0.11' ]]; then
+          TF12=0.12.30
           TF13=$(terraform-0.13 version --json | jq -r .terraform_version)
           TF14=$(terraform-0.14 version --json | jq -r .terraform_version)
           # vert exits non-zero if any of the versions are not acceptable, so `|| [[ -n "$VERSION" ]]` for a real error check

--- a/codefresh/pipeline-creator/Dockerfile
+++ b/codefresh/pipeline-creator/Dockerfile
@@ -1,4 +1,4 @@
-FROM codefresh/cli:0.74.4
+FROM codefresh/cli:0.74.9
 
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 

--- a/codefresh/pipeline-runner/Dockerfile
+++ b/codefresh/pipeline-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM codefresh/cli:0.74.4
+FROM codefresh/cli:0.74.9
 
 LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
 


### PR DESCRIPTION
## what
- Select Terraform version via `versions.tf`, with legacy support for `/0.11` branches
- [renovate] Update cloudposse/actions action to v0.28.0 (#88) 
- [renovate]  Update codefresh/cli Docker tag to v0.74.9 (#100) 

## why
- We used to primarily select the Terraform version via branch name, but that causes problems when branch names are not what we expect. Now we only support the `/0.11` branch name and otherwise use `versions.tf` to determine which version of Terraform to run.