### PR TITLE
Adding new 'crud' github action

### DIFF
--- a/github/crud/Dockerfile
+++ b/github/crud/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.12
+
+LABEL maintainer="Cloud Posse <hello@cloudposse.com>"
+
+LABEL "com.github.actions.name"="CRUD"
+LABEL "com.github.actions.description"="Synchronize Github workflows to a repository"
+LABEL "com.github.actions.icon"="activity"
+LABEL "com.github.actions.color"="blue"
+
+COPY entrypoint.sh /
+
+RUN chmod 755 /entrypoint.sh \
+  && apk --no-cache add bash git
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/github/crud/action.yaml
+++ b/github/crud/action.yaml
@@ -1,0 +1,19 @@
+name: 'crud'
+description: 'Synchronize Github workflows to a repository'
+author: 'Cloud Posse <hello@cloudposse.com>'
+inputs:
+  repo:
+    required: true
+  catalog:
+    required: true
+  version:
+    required: false
+    default: master
+  workflows:
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+branding:
+  icon: 'activity'
+  color: 'blue'

--- a/github/crud/entrypoint.sh
+++ b/github/crud/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eu
+
+echo REPO: $INPUT_REPO
+echo VERSION: $INPUT_VERSION
+echo WORKFLOWS: $INPUT_WORKFLOWS
+echo CATALOG: $INPUT_CATALOG
+
+git clone --branch ${INPUT_VERSION} ${INPUT_REPO} ../actions
+
+for workflow in $(tr , ' ' <<<${INPUT_WORKFLOWS}); do 
+  # Install the workflow
+  cp -a ../actions/${INPUT_CATALOG}/${workflow}.yaml .github/workflows/
+done


### PR DESCRIPTION
## what & why?

This new `crud` Github action clones a user-specified actions repository (`repo` and `version`) and copies the comma-delimited list of workflows (`workflow`) from a specific catalog (`catalog`) into the `.github/workflows` folder of the repository running this `crud` Github action.

