### PR TITLE
test-harness uses different grep than Geodesic default

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -222,7 +222,8 @@ jobs:
         fi
 
         # Match lables like `terraform/0.12` or nothing (to prevent non-zero exit code)
-        OVERRIDE_VERSION=$(grep -Eo '(terraform/\d+\.\d+|)' <<<${LABELS} | cut -d/ -f2)
+        # Use [0-9] because \d is not standard part of egrep
+        OVERRIDE_VERSION=$(grep -Eo '(terraform/[0-9]+\.[0-9]+|)' <<<${LABELS} | cut -d/ -f2)
 
         if [ -n "${OVERRIDE_VERSION}" ]; then
           VERSION=${OVERRIDE_VERSION}
@@ -351,7 +352,8 @@ jobs:
         fi
 
         # Match lables like `terraform/0.12` or nothing (to prevent non-zero exit code)
-        OVERRIDE_VERSION=$(grep -Eo '(terraform/\d+\.\d+|)' <<<${LABELS} | cut -d/ -f2)
+        # Use [0-9] because \d is not standard part of egrep
+        OVERRIDE_VERSION=$(grep -Eo '(terraform/[0-9]+\.[0-9]+|)' <<<${LABELS} | cut -d/ -f2)
 
         if [ -n "${OVERRIDE_VERSION}" ]; then
           VERSION=${OVERRIDE_VERSION}


### PR DESCRIPTION
## what
- Fix `grep` expression broken by switch from `testing.cloudposse.co` to `test-harness`

## why
- `grep -E` in native Alpine `grep` recognizes `\d` as any digit, but Gnu `grep` does not (has -p flag for PCRE), because that is the POSIX standard. As a result, parsing PR labels for Terraform versions was broken.