### PR TITLE
Use args with status updater instead of env vars, update checkout to v3

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -72,19 +72,23 @@ jobs:
     if: needs.parse.outputs.run-ping == 'true'
     steps:
     # Update GitHub status for dispatch events
+    # Use command line args because GitHub actions reserves `GITHUB_*` environment variables
     - name: "Update GitHub Status for this ref"
       #if: ${{ github.event_name == 'repository_dispatch' }}
       uses: 'docker://cloudposse/github-status-updater'
       with:
         # We need to use args because GitHub actions overwrites many `GITHUB_*` environment variables
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}" 
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state success
+          -context "test/ping"
+          -description pong
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: success
-        GITHUB_CONTEXT: 'test/ping'
-        GITHUB_DESCRIPTION: "pong"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
   readme:
     runs-on: ubuntu-latest
@@ -95,23 +99,27 @@ jobs:
       MAKE_INCLUDES: Makefile
     steps:
     # Update GitHub status for dispatch events
+    # Use command line args because GitHub actions reserves `GITHUB_*` environment variables
     - name: "Update GitHub Status for pending"
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}" 
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state pending
+          -context "test/readme"
+          -description "Tests started by @${{ github.event.client_payload.github.actor }}"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: pending
-        GITHUB_CONTEXT: "test/readme"
-        GITHUB_DESCRIPTION: "tests started by @${{ github.event.client_payload.github.actor }}"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
 
     # Checkout the code from GitHub Pull Request
     - name: "Checkout code for ChatOps"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
@@ -132,44 +140,53 @@ jobs:
       if: ${{ failure() }}
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state failure
+          -context "test/readme"
+          -description "Tests failed"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: failure
-        GITHUB_CONTEXT: "test/readme"
-        GITHUB_DESCRIPTION: "tests failed"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for success"
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state success
+          -context "test/readme"
+          -description "Tests passed"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: success
-        GITHUB_CONTEXT: "test/readme"
-        GITHUB_DESCRIPTION: "tests passed"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for cancelled"
       if: ${{ cancelled() }}
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state error
+          -context "test/readme"
+          -description "Tests cancelled"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: error
-        GITHUB_CONTEXT: "test/readme"
-        GITHUB_DESCRIPTION: "tests cancelled"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
   bats:
     runs-on: ubuntu-latest
@@ -184,19 +201,22 @@ jobs:
     - name: "Update GitHub Status for pending"
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state pending
+          -context "test/bats"
+          -description "Tests started by @${{ github.event.client_payload.github.actor }}"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: pending
-        GITHUB_CONTEXT: "test/bats"
-        GITHUB_DESCRIPTION: "tests started by @${{ github.event.client_payload.github.actor }}"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Checkout the code from GitHub Pull Request
     - name: "Checkout code for ChatOps"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
@@ -265,44 +285,53 @@ jobs:
       if: ${{ failure() }}
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state failure
+          -context "test/bats"
+          -description "Tests failed"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: failure
-        GITHUB_CONTEXT: "test/bats"
-        GITHUB_DESCRIPTION: "tests failed"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for success"
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state success
+          -context "test/bats"
+          -description "Tests passed"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: success
-        GITHUB_CONTEXT: "test/bats"
-        GITHUB_DESCRIPTION: "tests passed"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for cancelled"
       if: ${{ cancelled() }}
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state error
+          -context "test/bats"
+          -description "Tests cancelled"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: error
-        GITHUB_CONTEXT: "test/bats"
-        GITHUB_DESCRIPTION: "tests cancelled"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
   terratest:
     runs-on: ubuntu-latest
@@ -316,19 +345,22 @@ jobs:
     - name: "Update GitHub Status for pending"
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state pending
+          -context "test/terratest"
+          -description "Tests started by @${{ github.event.client_payload.github.actor }}"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: pending
-        GITHUB_CONTEXT: "test/terratest"
-        GITHUB_DESCRIPTION: "tests started by @${{ github.event.client_payload.github.actor }}"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Checkout the code from GitHub Pull Request
     - name: "Checkout code for ChatOps"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
@@ -460,42 +492,51 @@ jobs:
       if: ${{ failure() }}
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state failure
+          -context "test/terratest"
+          -description "Tests failed"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: failure
-        GITHUB_CONTEXT: "test/terratest"
-        GITHUB_DESCRIPTION: "tests failed"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for this success"
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state success
+          -context "test/terratest"
+          -description "Tests passed"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: success
-        GITHUB_CONTEXT: "test/terratest"
-        GITHUB_DESCRIPTION: "tests passed"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 
     # Update GitHub status for dispatch events
     - name: "Update GitHub Status for cancelled"
       if: ${{ cancelled() }}
       uses: docker://cloudposse/github-status-updater
       with:
-        args: "-action update_state -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        args: >-
+          -action update_state 
+          -ref "${{ github.event.client_payload.pull_request.head.sha }}"
+          -repo "${{ github.event.client_payload.github.payload.repository.name }}"
+          -state error
+          -context "test/terratest"
+          -description "Tests cancelled"
+          -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
+          -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-        GITHUB_STATE: error
-        GITHUB_CONTEXT: "test/terratest"
-        GITHUB_DESCRIPTION: "tests cancelled"
-        GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
-        GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
 

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -111,7 +111,6 @@ jobs:
           -context "test/readme"
           -description "Tests started by @${{ github.event.client_payload.github.actor }}"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -148,7 +147,6 @@ jobs:
           -context "test/readme"
           -description "Tests failed"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -165,7 +163,6 @@ jobs:
           -context "test/readme"
           -description "Tests passed"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -183,7 +180,6 @@ jobs:
           -context "test/readme"
           -description "Tests cancelled"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -209,7 +205,6 @@ jobs:
           -context "test/bats"
           -description "Tests started by @${{ github.event.client_payload.github.actor }}"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -293,7 +288,6 @@ jobs:
           -context "test/bats"
           -description "Tests failed"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -310,7 +304,6 @@ jobs:
           -context "test/bats"
           -description "Tests passed"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -328,7 +321,6 @@ jobs:
           -context "test/bats"
           -description "Tests cancelled"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -353,7 +345,6 @@ jobs:
           -context "test/terratest"
           -description "Tests started by @${{ github.event.client_payload.github.actor }}"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -500,7 +491,6 @@ jobs:
           -context "test/terratest"
           -description "Tests failed"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -517,7 +507,6 @@ jobs:
           -context "test/terratest"
           -description "Tests passed"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
@@ -535,7 +524,6 @@ jobs:
           -context "test/terratest"
           -description "Tests cancelled"
           -url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          -ref "${{ github.event.client_payload.pull_request.head.ref }}"
           -owner "${{ github.event.client_payload.github.payload.repository.owner.login }}"
       env:
         GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## what
- Use command line arguments to `github-status-updater` instead of environment variables
- Update `actions/checkout` from v2 to current v3

## why
- The environment variables `github-status-updater` uses conflict with the GitHub Actions reserved namespace. In particular, sometime around 2022-09-28, GitHub actions began setting `GITHUB_STATE`, overriding the input to `github-status-updater` and causing it to fail. This in turn cause all our automated testing to fail.
- Security updates, use more current version of NodeJS

## references
- https://github.com/actions/checkout/releases/tag/v3.0.0
