### PR TITLE
Update github output syntax

### DIFF
--- a/github/slash-command-dispatch/.github/workflows/hello-world-command.yml
+++ b/github/slash-command-dispatch/.github/workflows/hello-world-command.yml
@@ -14,8 +14,8 @@ jobs:
 
       - name: Create URL to the run output
         id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
+        run: echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+        
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v2
         with:


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/