### PR TITLE
Update github output syntax

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -50,7 +50,7 @@ jobs:
           done
         fi
         for out in REACTION "${COMMANDS[@]}"; do
-          printf "::set-output name=%s::%s\n" "${out,,}" "${!out:-false}"
+          printf "name=%s=%s\n" "${out,,}" "${!out:-false}" >> $GITHUB_OUTPUT
           printf "%s=%s\n" "${out,,}" "${!out:-false}"
         done
 


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/