### PR TITLE
Use `peter-evans/create-or-update-comment@v4` for comments reactions

### DIFF
--- a/.github/workflows/terratest-command.yml
+++ b/.github/workflows/terratest-command.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.client_payload.github.payload.comment.id != ''
     steps:
       - name: "Add reaction"
-        uses: cloudposse/actions/github/create-or-update-comment@0.33.0
+        uses: peter-evans/create-or-update-comment@v4
         with:
           repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}


### PR DESCRIPTION
## what
* Use `peter-evans/create-or-update-comment@v4` for comments reactions instead of cached [cloudposse/actions/github/create-or-update-comment](https://github.com/cloudposse/actions/tree/master/github/create-or-update-comment).

## why
* DEV-2051 ticket - "Update terratest-command GHA workflow to use create-or-update-comment v4 directly, not the outdated cached version"

## references
* https://cloudposse.atlassian.net/browse/DEV-2051