### PR TITLE
Increase concurrency for terratest

### DIFF
--- a/.github/workflows/terratest-command.yml
+++ b/.github/workflows/terratest-command.yml
@@ -47,7 +47,7 @@ jobs:
       MAKE_INCLUDES: Makefile
     continue-on-error: true
     strategy:
-      max-parallel: 1
+      max-parallel: 10
       fail-fast: false # Don't fail fast to avoid locking TF State
       matrix:
         platform: [terraform, opentofu]


### PR DESCRIPTION
## what
* Increase concurrency for terratest

## why
* Reduce CI / CD run time

## references
* DEV-2349 Increase concurrency for Opentofu testing
